### PR TITLE
Edit team members

### DIFF
--- a/daily-blueprint-capstone/Controllers/TeamsController.cs
+++ b/daily-blueprint-capstone/Controllers/TeamsController.cs
@@ -55,6 +55,21 @@ namespace daily_blueprint_capstone.Controllers
         {
             var removeTeamMember = _repository.RemoveTeamMember(teamMemberToRemove);
             if (removeTeamMember == 0) NotFound("This team member could not be removed.");
+            var otherTeams = _repository.GetTeamsByUser(teamMemberToRemove.UserId);
+            if (otherTeams.Any())
+            {
+                var hasPrimary = otherTeams.FirstOrDefault((t) => t.isPrimary);
+                if (hasPrimary == null)
+                {
+                    var newPrimary = otherTeams.First();
+                    var newPrimaryBasic = new TeamMembersBasic();
+                    newPrimaryBasic.UserId = teamMemberToRemove.UserId;
+                    newPrimaryBasic.TeamId = newPrimary.TeamId;
+                    var changePrimary = _repository.AddPrimaryTeam(newPrimaryBasic);
+                    if (changePrimary == null) return NotFound("This team member was removed, but a new primary team could not be assigned.");
+                    return Ok(changePrimary);
+                }
+            }
             return Ok("This team member has been removed");
         }
     }

--- a/daily-blueprint-capstone/Controllers/TeamsController.cs
+++ b/daily-blueprint-capstone/Controllers/TeamsController.cs
@@ -41,5 +41,21 @@ namespace daily_blueprint_capstone.Controllers
             if (newPrimary == null) return NotFound("This team could not be found");
             return Ok(newPrimary);
         }
+
+        [HttpPost("TeamMember")]
+        public IActionResult CreateTeamMember(TeamMembers teamMemberObj)
+        {
+            var newTeammate = _repository.AddTeamMember(teamMemberObj);
+            if (newTeammate == null) return NotFound("This team member could not be added.");
+            return Ok(newTeammate);
+        }
+
+        [HttpDelete("TeamMember/delete")]
+        public IActionResult DeleteTeamMember(TeamMembersBasic teamMemberToRemove)
+        {
+            var removeTeamMember = _repository.RemoveTeamMember(teamMemberToRemove);
+            if (removeTeamMember == 0) NotFound("This team member could not be removed.");
+            return Ok("This team member has been removed");
+        }
     }
 }

--- a/daily-blueprint-capstone/Controllers/UsersController.cs
+++ b/daily-blueprint-capstone/Controllers/UsersController.cs
@@ -38,5 +38,14 @@ namespace daily_blueprint_capstone.Controllers
             var newUser = _repository.SaveNewUser(UserToAdd);
             return Ok(newUser);
         }
+
+        [HttpGet("organization/{orgId}")]
+        public IActionResult GetAllUsersByOrg(int orgId)
+        {
+            var orgUsers = _repository.GetUsersByOrgId(orgId);
+            var isEmpty = !orgUsers.Any();
+            if (isEmpty) return NotFound("No users have signed up for this organization");
+            return Ok(orgUsers);
+        }
     }
 }

--- a/daily-blueprint-capstone/DataAccessLayer/TeamsRepo.cs
+++ b/daily-blueprint-capstone/DataAccessLayer/TeamsRepo.cs
@@ -23,7 +23,8 @@ namespace daily_blueprint_capstone.DataAccessLayer
                         from TeamMembers TM
 	                        join Teams T
 	                        on TM.teamId = T.id
-                        where TM.userId = @UserId";
+                        where TM.userId = @UserId
+                        order by TeamName";
 
             using(var db = new SqlConnection(ConnectionString))
             {
@@ -90,14 +91,17 @@ namespace daily_blueprint_capstone.DataAccessLayer
 
         public int RemoveTeamMember(TeamMembersBasic memberToDelete)
         {
-            var query = @"delete from TeamMembers
+            var deleteQuery = @"delete from TeamMembers
                         where userId = @UserId
                         and teamId = @TeamId";
 
             using (var db = new SqlConnection(ConnectionString))
             {
-                return db.Execute(query, memberToDelete);
+                var removed = db.Execute(deleteQuery, memberToDelete);
+                return removed;
             }
         }
+
+
     }
 }

--- a/daily-blueprint-capstone/DataAccessLayer/TeamsRepo.cs
+++ b/daily-blueprint-capstone/DataAccessLayer/TeamsRepo.cs
@@ -59,5 +59,45 @@ namespace daily_blueprint_capstone.DataAccessLayer
                 return db.QueryFirstOrDefault<Teams>(query, teamObj);
             }
         }
+
+        public TeamMembers FindPrimaryTeam(int userId)
+        {
+            var query = @"select * from TeamMembers
+                        where userId = @userId
+                        and isPrimary = 1";
+            
+            using (var db = new SqlConnection(ConnectionString))
+            {
+                var parameters = new { UserId = userId };
+                return db.QueryFirstOrDefault<TeamMembers>(query, parameters);
+            }
+        }
+
+        public TeamMembers AddTeamMember(TeamMembers newTeamMember)
+        {
+            var hasPrimary = FindPrimaryTeam(newTeamMember.UserId);
+            if (hasPrimary == null) newTeamMember.isPrimary = true;
+
+            var query = @"insert into TeamMembers(userId, teamId, isTeamLead, isPrimary)
+                        output inserted.*
+                        values(@userId, @teamId, @isTeamLead, @isPrimary)";
+
+            using (var db = new SqlConnection(ConnectionString))
+            {
+                return db.QueryFirstOrDefault<TeamMembers>(query, newTeamMember);
+            }
+        }
+
+        public int RemoveTeamMember(TeamMembersBasic memberToDelete)
+        {
+            var query = @"delete from TeamMembers
+                        where userId = @UserId
+                        and teamId = @TeamId";
+
+            using (var db = new SqlConnection(ConnectionString))
+            {
+                return db.Execute(query, memberToDelete);
+            }
+        }
     }
 }

--- a/daily-blueprint-capstone/DataAccessLayer/ToDosRepo.cs
+++ b/daily-blueprint-capstone/DataAccessLayer/ToDosRepo.cs
@@ -40,7 +40,8 @@ namespace daily_blueprint_capstone.DataAccessLayer
                             join toDos t
                             on p.toDoId = t.id
                         where t.ownerUserId = @UserId
-                        and t.isComplete = 0";
+                        and t.isComplete = 0
+                        order by PriorityDate";
 
             using(var db = new SqlConnection(ConnectionString))
             {
@@ -60,7 +61,8 @@ namespace daily_blueprint_capstone.DataAccessLayer
             var query = @"select *
                         from toDos 
                         where ownerUserId = @UserId
-                        and isComplete = 0";
+                        and isComplete = 0
+                        order by DateDue";
 
             var priorities = GetPrioritiesByUser(userId).ToList();
 
@@ -92,7 +94,8 @@ namespace daily_blueprint_capstone.DataAccessLayer
                             join users u
                             on td.ownerUserId = u.id
                         where tg.userId = @userId
-                        and td.isComplete = 0";
+                        and td.isComplete = 0
+                        order by DateDue";
 
             using (var db = new SqlConnection(ConnectionString))
             {
@@ -131,7 +134,8 @@ namespace daily_blueprint_capstone.DataAccessLayer
                         from TeamMembers TM
 	                        join Users U
 	                        on TM.UserId = U.Id
-                        where TM.TeamId = @TeamId";
+                        where TM.TeamId = @TeamId
+                        order by FirstName";
 
             using (var db = new SqlConnection(ConnectionString))
             {

--- a/daily-blueprint-capstone/DataAccessLayer/UsersRepo.cs
+++ b/daily-blueprint-capstone/DataAccessLayer/UsersRepo.cs
@@ -41,5 +41,17 @@ namespace daily_blueprint_capstone.DataAccessLayer
                 return db.Query<Users>(query, UserToAdd);
             }
         }
+
+        public IEnumerable<Users> GetUsersByOrgId(int orgId)
+        {
+            var query = @"select * from Users
+                        where organizationId = @OrgId";
+
+            using (var db = new SqlConnection(ConnectionString))
+            {
+                var parameters = new { OrgId = orgId };
+                return db.Query<Users>(query, parameters);
+            }
+        }
     }
 }

--- a/daily-blueprint-capstone/DataAccessLayer/UsersRepo.cs
+++ b/daily-blueprint-capstone/DataAccessLayer/UsersRepo.cs
@@ -45,7 +45,8 @@ namespace daily_blueprint_capstone.DataAccessLayer
         public IEnumerable<Users> GetUsersByOrgId(int orgId)
         {
             var query = @"select * from Users
-                        where organizationId = @OrgId";
+                        where organizationId = @OrgId
+                        order by FirstName";
 
             using (var db = new SqlConnection(ConnectionString))
             {

--- a/daily-blueprint-capstone/Models/TeamMembers.cs
+++ b/daily-blueprint-capstone/Models/TeamMembers.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace daily_blueprint_capstone.Models
+{
+    public class TeamMembers
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public int TeamId { get; set; }
+        public bool isTeamLead { get; set; }
+        public bool isPrimary { get; set; }
+    }
+}

--- a/daily-blueprint.ui/src/components/pages/Team/Team.js
+++ b/daily-blueprint.ui/src/components/pages/Team/Team.js
@@ -83,7 +83,7 @@ class Team extends React.Component {
           <div>
             <h2 className='teamName'>{teamToDisplay.teamName}</h2>
             { !teamToDisplay.isPrimary && <button className='btn btn-outline-light' onClick={this.changePrimaryTeam}>Make Primary</button> }
-            { !teamToDisplay.isTeamLead && <button className='btn btn-outline-light' onClick={this.toggleTeamModal}>Edit Team</button> }
+            { teamToDisplay.isTeamLead && <button className='btn btn-outline-light' onClick={this.toggleTeamModal}>Edit Team</button> }
 
           </div>
           { teams.length > 1 && <form>
@@ -94,7 +94,8 @@ class Team extends React.Component {
           </form> }
         </div>
         {buildMemberPriorityCards}
-        <TeamMemberModal team={teamToDisplay} teamPriorities={teamPriorities} teamModalIsOpen={teamModalIsOpen} toggleTeamModal={this.toggleTeamModal} orgId={user.organizationId} />
+        <TeamMemberModal team={teamToDisplay} teamPriorities={teamPriorities} teamModalIsOpen={teamModalIsOpen} toggleTeamModal={this.toggleTeamModal}
+          orgId={user.organizationId} getAllTeamData={this.getAllTeamData} userId={user.id} />
       </div>
     );
   }

--- a/daily-blueprint.ui/src/components/pages/Team/Team.js
+++ b/daily-blueprint.ui/src/components/pages/Team/Team.js
@@ -5,12 +5,14 @@ import teamsData from '../../../helpers/data/teamsData';
 import UserShape from '../../../helpers/propz/UserShape';
 import toDoData from '../../../helpers/data/toDoData';
 import TeamPriorityCard from '../../shared/TeamPriorityCard/TeamPriorityCard';
+import TeamMemberModal from '../../shared/TeamMemberModal/TeamMemberModal';
 
 class Team extends React.Component {
   state = {
     teams: [],
     teamToDisplay: {},
     teamPriorities: [],
+    teamModalIsOpen: false,
   }
 
   static propTypes = {
@@ -38,6 +40,10 @@ class Team extends React.Component {
       .catch((errorFromGetPrioritiesForCurrentTeam) => console.error(errorFromGetPrioritiesForCurrentTeam));
   };
 
+  toggleTeamModal = () => {
+    this.setState({ teamModalIsOpen: !this.state.teamModalIsOpen });
+  }
+
   updateTeamDisplay = (e) => {
     e.preventDefault();
     const teamsArr = this.state.teams;
@@ -58,7 +64,13 @@ class Team extends React.Component {
   }
 
   render() {
-    const { teams, teamToDisplay, teamPriorities } = this.state;
+    const {
+      teams,
+      teamToDisplay,
+      teamPriorities,
+      teamModalIsOpen,
+    } = this.state;
+    const { user } = this.props;
     const currentDate = Moment().format('dddd, LL');
 
     const buildMemberPriorityCards = teamPriorities.map((p) => <TeamPriorityCard key={`member-${p.userId}`} teamPriorities={p} />);
@@ -71,6 +83,8 @@ class Team extends React.Component {
           <div>
             <h2 className='teamName'>{teamToDisplay.teamName}</h2>
             { !teamToDisplay.isPrimary && <button className='btn btn-outline-light' onClick={this.changePrimaryTeam}>Make Primary</button> }
+            { !teamToDisplay.isTeamLead && <button className='btn btn-outline-light' onClick={this.toggleTeamModal}>Edit Team</button> }
+
           </div>
           { teams.length > 1 && <form>
             <select className='form-control mt-1' id='selectedTeam' value='' onChange={this.updateTeamDisplay}>
@@ -80,6 +94,7 @@ class Team extends React.Component {
           </form> }
         </div>
         {buildMemberPriorityCards}
+        <TeamMemberModal team={teamToDisplay} teamPriorities={teamPriorities} teamModalIsOpen={teamModalIsOpen} toggleTeamModal={this.toggleTeamModal} orgId={user.organizationId} />
       </div>
     );
   }

--- a/daily-blueprint.ui/src/components/shared/TeamMemberModal/TeamMemberModal.js
+++ b/daily-blueprint.ui/src/components/shared/TeamMemberModal/TeamMemberModal.js
@@ -23,10 +23,11 @@ class TeamMemberModal extends React.Component {
     teamModalIsOpen: PropTypes.bool,
     toggleTeamModal: PropTypes.func,
     userId: PropTypes.number,
+    orgId: PropTypes.number,
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.teamModalIsOpen && this.props.teamModalIsOpen !== prevProps.teamModalIsOpen) {
+    if (this.props.teamModalIsOpen && (this.props.teamModalIsOpen !== prevProps.teamModalIsOpen || this.props.teamPriorities !== prevProps.teamPriorities)) {
       const { orgId } = this.props;
       this.getAllUsers(orgId);
     }
@@ -54,7 +55,7 @@ class TeamMemberModal extends React.Component {
   addTeamMate = (e) => {
     e.preventDefault();
     const { checkTeamLead, userToAdd } = this.state;
-    const { team, orgId } = this.props;
+    const { team, userId, getAllTeamData } = this.props;
     const teamMate = {
       userId: Number(userToAdd),
       teamId: team.teamId,
@@ -62,28 +63,30 @@ class TeamMemberModal extends React.Component {
       isPrimary: false,
     };
     teamsData.addTeamMember(teamMate)
-      .then(() => this.getAllUsers(orgId))
-      .catch((errorFromAddTeammate) => console.error(errorFromAddTeammate));
+      .then(() => {
+        getAllTeamData(userId);
+        this.setState({ userToAdd: '', checkTeamLead: false });
+      }).catch((errorFromAddTeammate) => console.error(errorFromAddTeammate));
   }
 
   deleteTeamMate = (e) => {
     e.preventDefault();
-    const { team, orgId } = this.props;
+    const { team, getAllTeamData, userId } = this.props;
     const userToRemove = {
       userId: Number(e.target.value),
       teamId: team.teamId,
     };
-    console.log(userToRemove);
     teamsData.removeTeamMember(userToRemove)
-      .then(() => this.getAllUsers(orgId))
-      .catch((errorFromDeleteTeammate) => console.error(errorFromDeleteTeammate));
+      .then(() => {
+        getAllTeamData(userId);
+        this.setState({ userToAdd: '', checkTeamLead: false });
+      }).catch((errorFromDeleteTeammate) => console.error(errorFromDeleteTeammate));
   }
 
   dismissTeamModal = (e) => {
     e.preventDefault();
-    const { toggleTeamModal, getAllTeamData, userId } = this.props;
+    const { toggleTeamModal } = this.props;
     this.setState({ userToAdd: '', checkTeamLead: false });
-    getAllTeamData(userId);
     toggleTeamModal();
   }
 
@@ -98,21 +101,20 @@ class TeamMemberModal extends React.Component {
     this.setState({ userToAdd: userId });
   }
 
+  buildTeamList = () => this.state.teamMembers.map((t) => <div key={`teamMember-${t.id}`} className='col-sm-4 d-flex'><p>{`${t.firstName} ${t.lastName}`}</p>
+      <button className='btn close' value={t.id} onClick={this.deleteTeamMate}>X</button></div>);
+
+  buildStaffDropdown = () => this.state.unassignedUsers.map((u) => <option key={`staff-${u.id}`} value={u.id}>{`${u.firstName} ${u.lastName}`}</option>);
+
   render() {
     const {
       checkTeamLead,
-      teamMembers,
-      unassignedUsers,
       userToAdd,
     } = this.state;
     const {
       teamModalIsOpen,
       toggleTeamModal,
     } = this.props;
-
-    const buildTeamList = () => teamMembers.map((t) => <div key={`teamMember-${t.id}`} className='col-sm-4 d-flex'><p>{`${t.firstName} ${t.lastName}`}</p>
-      <button className='btn close' value={t.id} onClick={this.deleteTeamMate}>X</button></div>);
-    const buildStaffDropdown = () => unassignedUsers.map((u) => <option key={`staff-${u.id}`} value={u.id}>{`${u.firstName} ${u.lastName}`}</option>);
 
     return (
       <div className='TeamMemberModal'>
@@ -122,18 +124,18 @@ class TeamMemberModal extends React.Component {
               <form className='unassignedUsers'>
                 <select className='form-control' id='userInput' value={userToAdd} onChange={this.userToAddChange}>
                   <option value='' disabled defaultValue>Select a Team Member</option>
-                  {buildStaffDropdown()}
+                  {this.buildStaffDropdown()}
                 </select>
                 <div>
                   <div>
-                    <input type='checkbox' className='teamLeadCheckbox' data-val='true' id='teamLeadCheck' value={checkTeamLead} onChange={this.teamLeadChange} />
+                    <input type='checkbox' className='teamLeadCheckbox' data-val='true' id='teamLeadCheck' checked={checkTeamLead} onChange={this.teamLeadChange} />
                     <label htmlFor='teamLeadCheck'>Make User Team Lead</label>
                   </div>
                   <button className='btn btn-secondary' onClick={this.addTeamMate}>Add</button>
                 </div>
               </form>
               <div className='teamMemembers d-flex flex-wrap'>
-                {buildTeamList()}
+                {this.buildTeamList()}
               </div>
               <Button className='dismissModal' onClick={this.dismissTeamModal}>Done</Button>
             </div>

--- a/daily-blueprint.ui/src/components/shared/TeamMemberModal/TeamMemberModal.js
+++ b/daily-blueprint.ui/src/components/shared/TeamMemberModal/TeamMemberModal.js
@@ -5,25 +5,31 @@ import PropTypes from 'prop-types';
 import TeamPrioritiesShape from '../../../helpers/propz/TeamPrioritiesShape';
 import TeamShape from '../../../helpers/propz/TeamShape';
 import userData from '../../../helpers/data/userData';
+import teamsData from '../../../helpers/data/teamsData';
 
 class TeamMemberModal extends React.Component {
   state = {
     checkTeamLead: false,
     teamMembers: [],
     unassignedUsers: [],
+    userToAdd: '',
   }
 
   static propTypes = {
+    getAllTeamData: PropTypes.func,
     organizationId: PropTypes.number,
     teamPriorities: PropTypes.arrayOf(TeamPrioritiesShape.teamPrioritiesShape),
-    teamToDisplay: TeamShape.teamShape,
+    team: TeamShape.teamShape,
     teamModalIsOpen: PropTypes.bool,
     toggleTeamModal: PropTypes.func,
+    userId: PropTypes.number,
   }
 
-  componentDidMount() {
-    const { orgId } = this.props;
-    this.getAllUsers(orgId);
+  componentDidUpdate(prevProps) {
+    if (this.props.teamModalIsOpen && this.props.teamModalIsOpen !== prevProps.teamModalIsOpen) {
+      const { orgId } = this.props;
+      this.getAllUsers(orgId);
+    }
   }
 
   getAllUsers = (orgId) => {
@@ -35,14 +41,50 @@ class TeamMemberModal extends React.Component {
         const unassigned = [];
         allUsers.forEach((u) => {
           const teamMate = teamPriorities.find((tp) => tp.userId === u.id);
-          if (teamMate) {
-            team.push(u);
-          } else {
+          if (teamMate === undefined) {
             unassigned.push(u);
+          } else {
+            team.push(u);
           }
         });
         this.setState({ teamMembers: team, unassignedUsers: unassigned });
       }).catch((errorFromGetAllUsers) => console.error(errorFromGetAllUsers));
+  }
+
+  addTeamMate = (e) => {
+    e.preventDefault();
+    const { checkTeamLead, userToAdd } = this.state;
+    const { team, orgId } = this.props;
+    const teamMate = {
+      userId: Number(userToAdd),
+      teamId: team.teamId,
+      isTeamLead: checkTeamLead,
+      isPrimary: false,
+    };
+    teamsData.addTeamMember(teamMate)
+      .then(() => this.getAllUsers(orgId))
+      .catch((errorFromAddTeammate) => console.error(errorFromAddTeammate));
+  }
+
+  deleteTeamMate = (e) => {
+    e.preventDefault();
+    const { team, orgId } = this.props;
+    const userToRemove = {
+      userId: Number(e.target.value),
+      teamId: team.teamId,
+    };
+    console.log(userToRemove);
+    teamsData.removeTeamMember(userToRemove)
+      .then(() => this.getAllUsers(orgId))
+      .catch((errorFromDeleteTeammate) => console.error(errorFromDeleteTeammate));
+  }
+
+  dismissTeamModal = (e) => {
+    e.preventDefault();
+    const { toggleTeamModal, getAllTeamData, userId } = this.props;
+    this.setState({ userToAdd: '', checkTeamLead: false });
+    getAllTeamData(userId);
+    toggleTeamModal();
   }
 
   teamLeadChange = (e) => {
@@ -50,14 +92,27 @@ class TeamMemberModal extends React.Component {
     this.setState({ checkTeamLead: isLead });
   }
 
+  userToAddChange = (e) => {
+    e.preventDefault();
+    const userId = e.target.value;
+    this.setState({ userToAdd: userId });
+  }
+
   render() {
-    const { checkTeamLead, teamMembers, unassignedUsers } = this.state;
+    const {
+      checkTeamLead,
+      teamMembers,
+      unassignedUsers,
+      userToAdd,
+    } = this.state;
     const {
       teamModalIsOpen,
       toggleTeamModal,
     } = this.props;
 
-    const buildTeamList = () => teamMembers.map((t) => <div key={`teamMember-${t.id}`} className='col-sm-4 d-flex'><p>{`${t.firstName} ${t.lastName}`}</p><button className='btn close'>X</button></div>);
+    const buildTeamList = () => teamMembers.map((t) => <div key={`teamMember-${t.id}`} className='col-sm-4 d-flex'><p>{`${t.firstName} ${t.lastName}`}</p>
+      <button className='btn close' value={t.id} onClick={this.deleteTeamMate}>X</button></div>);
+    const buildStaffDropdown = () => unassignedUsers.map((u) => <option key={`staff-${u.id}`} value={u.id}>{`${u.firstName} ${u.lastName}`}</option>);
 
     return (
       <div className='TeamMemberModal'>
@@ -65,19 +120,22 @@ class TeamMemberModal extends React.Component {
           <ModalBody>
             <div>
               <form className='unassignedUsers'>
-                <select></select>
+                <select className='form-control' id='userInput' value={userToAdd} onChange={this.userToAddChange}>
+                  <option value='' disabled defaultValue>Select a Team Member</option>
+                  {buildStaffDropdown()}
+                </select>
                 <div>
                   <div>
                     <input type='checkbox' className='teamLeadCheckbox' data-val='true' id='teamLeadCheck' value={checkTeamLead} onChange={this.teamLeadChange} />
                     <label htmlFor='teamLeadCheck'>Make User Team Lead</label>
                   </div>
-                  <button className='btn btn-secondary'>Add</button>
+                  <button className='btn btn-secondary' onClick={this.addTeamMate}>Add</button>
                 </div>
               </form>
               <div className='teamMemembers d-flex flex-wrap'>
-                {buildTeamList}
+                {buildTeamList()}
               </div>
-              <Button className='dismissModal' onClick={this.toggleTeamModal}>Done</Button>
+              <Button className='dismissModal' onClick={this.dismissTeamModal}>Done</Button>
             </div>
           </ModalBody>
         </Modal>

--- a/daily-blueprint.ui/src/components/shared/TeamMemberModal/TeamMemberModal.js
+++ b/daily-blueprint.ui/src/components/shared/TeamMemberModal/TeamMemberModal.js
@@ -1,0 +1,89 @@
+import './TeamMemberModal.scss';
+import React from 'react';
+import { Button, Modal, ModalBody } from 'reactstrap';
+import PropTypes from 'prop-types';
+import TeamPrioritiesShape from '../../../helpers/propz/TeamPrioritiesShape';
+import TeamShape from '../../../helpers/propz/TeamShape';
+import userData from '../../../helpers/data/userData';
+
+class TeamMemberModal extends React.Component {
+  state = {
+    checkTeamLead: false,
+    teamMembers: [],
+    unassignedUsers: [],
+  }
+
+  static propTypes = {
+    organizationId: PropTypes.number,
+    teamPriorities: PropTypes.arrayOf(TeamPrioritiesShape.teamPrioritiesShape),
+    teamToDisplay: TeamShape.teamShape,
+    teamModalIsOpen: PropTypes.bool,
+    toggleTeamModal: PropTypes.func,
+  }
+
+  componentDidMount() {
+    const { orgId } = this.props;
+    this.getAllUsers(orgId);
+  }
+
+  getAllUsers = (orgId) => {
+    const { teamPriorities } = this.props;
+    userData.getAllUsersByOrg(orgId)
+      .then((results) => {
+        const allUsers = results.data;
+        const team = [];
+        const unassigned = [];
+        allUsers.forEach((u) => {
+          const teamMate = teamPriorities.find((tp) => tp.userId === u.id);
+          if (teamMate) {
+            team.push(u);
+          } else {
+            unassigned.push(u);
+          }
+        });
+        this.setState({ teamMembers: team, unassignedUsers: unassigned });
+      }).catch((errorFromGetAllUsers) => console.error(errorFromGetAllUsers));
+  }
+
+  teamLeadChange = (e) => {
+    const isLead = e.target.checked;
+    this.setState({ checkTeamLead: isLead });
+  }
+
+  render() {
+    const { checkTeamLead, teamMembers, unassignedUsers } = this.state;
+    const {
+      teamModalIsOpen,
+      toggleTeamModal,
+    } = this.props;
+
+    const buildTeamList = () => teamMembers.map((t) => <div key={`teamMember-${t.id}`} className='col-sm-4 d-flex'><p>{`${t.firstName} ${t.lastName}`}</p><button className='btn close'>X</button></div>);
+
+    return (
+      <div className='TeamMemberModal'>
+        <Modal isOpen={teamModalIsOpen} toggle={toggleTeamModal} className={'editTeamModal'}>
+          <ModalBody>
+            <div>
+              <form className='unassignedUsers'>
+                <select></select>
+                <div>
+                  <div>
+                    <input type='checkbox' className='teamLeadCheckbox' data-val='true' id='teamLeadCheck' value={checkTeamLead} onChange={this.teamLeadChange} />
+                    <label htmlFor='teamLeadCheck'>Make User Team Lead</label>
+                  </div>
+                  <button className='btn btn-secondary'>Add</button>
+                </div>
+              </form>
+              <div className='teamMemembers d-flex flex-wrap'>
+                {buildTeamList}
+              </div>
+              <Button className='dismissModal' onClick={this.toggleTeamModal}>Done</Button>
+            </div>
+          </ModalBody>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default TeamMemberModal;

--- a/daily-blueprint.ui/src/helpers/data/teamsData.js
+++ b/daily-blueprint.ui/src/helpers/data/teamsData.js
@@ -10,4 +10,13 @@ const getTeamsByUserId = (userId) => new Promise((resolve, reject) => {
 
 const updatePrimaryTeam = (teamObj) => axios.put(`${baseUrl}/primary`, teamObj);
 
-export default { getTeamsByUserId, updatePrimaryTeam };
+const addTeamMember = (teamMemberObj) => axios.post(`${baseUrl}/TeamMember`, teamMemberObj);
+
+const removeTeamMember = (teamMemberObj) => axios.delete(`${baseUrl}/TeamMember/delete`, teamMemberObj);
+
+export default {
+  getTeamsByUserId,
+  updatePrimaryTeam,
+  addTeamMember,
+  removeTeamMember,
+};

--- a/daily-blueprint.ui/src/helpers/data/teamsData.js
+++ b/daily-blueprint.ui/src/helpers/data/teamsData.js
@@ -12,7 +12,7 @@ const updatePrimaryTeam = (teamObj) => axios.put(`${baseUrl}/primary`, teamObj);
 
 const addTeamMember = (teamMemberObj) => axios.post(`${baseUrl}/TeamMember`, teamMemberObj);
 
-const removeTeamMember = (teamMemberObj) => axios.delete(`${baseUrl}/TeamMember/delete`, teamMemberObj);
+const removeTeamMember = (teamMemberObj) => axios.delete(`${baseUrl}/TeamMember/delete`, { data: teamMemberObj });
 
 export default {
   getTeamsByUserId,

--- a/daily-blueprint.ui/src/helpers/data/userData.js
+++ b/daily-blueprint.ui/src/helpers/data/userData.js
@@ -8,6 +8,12 @@ const getUserByFirebaseUid = (uid) => new Promise((resolve, reject) => {
     .catch((errFromUserData) => reject(errFromUserData));
 });
 
+const getAllUsersByOrg = (orgId) => new Promise((resolve, reject) => {
+  axios.get(`${baseUrl}/organization/${orgId}`)
+    .then((user) => resolve(user))
+    .catch((errFromUsersByOrg) => reject(errFromUsersByOrg));
+});
+
 const createUser = (userObj) => axios.post(`${baseUrl}/newUser`, userObj);
 
-export default { getUserByFirebaseUid, createUser };
+export default { getUserByFirebaseUid, getAllUsersByOrg, createUser };

--- a/daily-blueprint.ui/src/helpers/propz/TeamShape.js
+++ b/daily-blueprint.ui/src/helpers/propz/TeamShape.js
@@ -1,0 +1,10 @@
+import PropTypes from 'prop-types';
+
+const teamShape = PropTypes.shape({
+  teamId: PropTypes.number,
+  isTeamLead: PropTypes.bool.isRequired,
+  isPrimary: PropTypes.bool.isRequired,
+  TeamName: PropTypes.string.isRequired,
+});
+
+export default { teamShape };


### PR DESCRIPTION
* if user is a team lead they will have an edit team button
* edit team launches a modal that displays all existing team members with an X next to each, which removes the individual from the team
-- if this is the removed user's primary team and they are assigned to any other teams, another team will be assigned as primary
* the modal also has a drop down of all staff not on the team, select a user from the drop-down and click add to add the member to the team
-- if the user does not currently have a team, this one will be set as primary
-- checkbox controls if user is added as a team lead
* updated all get requests to include order by (by first name for users, priorityDate for priorities, and dateDue for other to dos)